### PR TITLE
disable auto command event trigger

### DIFF
--- a/autoload/tagalong/util.vim
+++ b/autoload/tagalong/util.vim
@@ -94,7 +94,7 @@ function! tagalong#util#GetMotion(motion)
   let saved_closing_visual = getpos("'>")
 
   let @z = ''
-  exec 'silent normal! '.a:motion.'"zy'
+  exec 'silent noautocmd normal! '.a:motion.'"zy'
   let text = @z
 
   if text == ''


### PR DESCRIPTION
When used with [highlightedyank](https://github.com/machakann/vim-highlightedyank), this plugin triggers TextYankPost and [highlightedyank](https://github.com/machakann/vim-highlightedyank) highlights everything inside tag.

Creator of [highlightedyank](https://github.com/machakann/vim-highlightedyank) suggested this fix, and I tested that on local machine (using neovim).
Solution works perfectly and seems that it doesn't break any functionality and stops unnecessarily highlight.

Original issue here (from highlightedyank): https://github.com/machakann/vim-highlightedyank/issues/47#issuecomment-782584079