### PR TITLE
Add eelixir to g:tagalong_filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ let g:tagalong_filetypes = ['html']
 Default value:
 
 ```
-['html', 'xml', 'jsx', 'eruby', 'ejs', 'eco', 'php', 'htmldjango', 'javascriptreact', 'typescriptreact']
+['html', 'xml', 'jsx', 'eruby', 'ejs', 'eco', 'php', 'htmldjango', 'javascriptreact', 'typescriptreact', 'eelixir']
 ```
 
 This variable holds all of the filetypes that the plugin will install mappings for. If, for some reason, you'd like to avoid its behaviour for particular markup languages, you can set the variable to a list of the ones you'd like to keep.

--- a/plugin/tagalong.vim
+++ b/plugin/tagalong.vim
@@ -20,6 +20,7 @@ if !exists('g:tagalong_filetypes')
         \ 'typescriptreact',
         \ 'vue',
         \ 'xml',
+        \ 'eelixir',
         \ ]
 endif
 


### PR DESCRIPTION
eelixir is used for various Elixir template formats:

https://github.com/elixir-editors/vim-elixir/blob/master/ftdetect/elixir.vim#L2